### PR TITLE
Mlong/get bucket creds

### DIFF
--- a/client.py
+++ b/client.py
@@ -107,3 +107,32 @@ class Client():
         req.raise_for_status()
         data = json.loads(req.text)
         return data
+
+    def get_storages(self):
+        req = self.session.get(self.api + "/v2/storage?key=" + self.key)
+        #req = self.session.get(self.api + "/v2/storage?key={}&namespace={}".format(self.key, namespace))
+        req.raise_for_status()
+        data = json.loads(req.text)
+        return data
+
+    #def start_storage(self, id: str):
+    #    req = self.session.post(
+    #        self.api + "/v2/storage/{}/provision?key={}".format(id, self.key))
+    #    req.raise_for_status()
+    #    return req.text
+
+    #def stop_storage(self, id):
+    #    req = self.session.delete(
+    #        self.api + "/resources/stop?key=" + self.key + "&id=" + id)
+    #    req.raise_for_status()
+    #    return req.text
+
+    def get_bucket_cred(self, id: str):
+        url = self.api + "/v2/vault/getBucketToken?key=" + self.key
+        payload = {
+            'bucketID': id,
+        }
+        req = self.session.post(url, json=payload)
+        req.raise_for_status()
+        data = json.loads(req.text)
+        return data 

--- a/getBucketCred.py
+++ b/getBucketCred.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+"""
+  This script will automatically connect to the NOAA ParallelWorks gateway to retrieve
+  information about the current clusters using the user's API key.
+
+  Critical files that must exist:
+
+    $HOME/.ssh/pw_api.key - this file must contain the API key in the first and only
+                            line.  Treat this file as any secure file and place in
+                            .ssh directory.  Change permissions to mode 600.
+"""
+
+import subprocess
+import json
+import requests
+import sys
+import time
+import os
+from client import Client
+
+# inputs
+PW_PLATFORM_HOST = None
+if 'PW_PLATFORM_HOST' in os.environ:
+    PW_PLATFORM_HOST = os.environ['PW_PLATFORM_HOST']
+else:
+    print("No PW_PLATFORM_HOST environment variable found. Please set it to the Parallel Works platform host name. e.g. cloud.parallel.works")
+    sys.exit(1)
+
+pw_url = "https://" + PW_PLATFORM_HOST
+
+# specify the clusters to start and wait for activation
+#clusters = ["gcluster_noaa"]
+buckets_to_access = sys.argv[1].split(',')
+
+print('\nGenerating credentials for buckets:', buckets_to_access)
+
+# Get user specific files
+homedir = os.environ['HOME']
+# The .hosts file will get re-written every time
+keyfile = homedir + '/.ssh/pw_api.key'
+
+# get my personal API key
+# with the environment variable PW_API_KEY taking precedence
+# over the file $HOME/.ssh/pw_api.key
+api_key = None
+if 'PW_API_KEY' in os.environ:
+    api_key = os.environ['PW_API_KEY']
+else:
+    try:
+        f = open(keyfile, "r")
+        api_key = f.readline().strip()
+        f.close()
+    except:
+        pass
+
+if api_key is None or api_key == "":
+    print("No API key found. Please set the environment variable PW_API_KEY or create the file $HOME/.ssh/pw_api.key.")
+    sys.exit(1)
+
+# create a new Parallel Works client
+c = Client(pw_url, api_key)
+
+# get the account username
+session = c.get_identity()
+
+user = session['username']
+print("\nRunning as user", user+'...')
+my_buckets = c.get_storages()
+for bucket_name in buckets_to_access:
+
+    try:
+        bucket_name = bucket_name.split('/')
+        bucket_namespace = bucket_name[0]
+        bucket_name = bucket_name[1]
+    except IndexError:
+        print("No namespace provided for", bucket_name[0]+".", "Default to current user", user)
+        bucket_name = bucket_name[0]
+        bucket_namespace = user
+
+    print("\nLooking for bucket", bucket_name, "in namespace", bucket_namespace+"...")
+
+    # check if resource exists
+    # find bucket_name in my_storages and map to ID
+    # this logic currently only lets you get creds for buckets you own
+    bucket = next(
+        (item for item in my_buckets if item["name"] == bucket_name and item["namespace"] == bucket_namespace), None)
+    if "bucket" not in bucket['type']:
+        print("Storage provided is not a bucket.")
+    elif bucket['provisioned'] != True:
+        print("Bucket provided is not currently provisioned.")
+    elif bucket:
+        print("Identified bucket", bucket['name'], "as", bucket['id'])
+
+        # generate short-term bucket credentials
+        print(c.get_bucket_cred(bucket['id']))
+    else:
+        print("No bucket found.")

--- a/getBucketCred.py
+++ b/getBucketCred.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 """
-  This script will automatically connect to the NOAA ParallelWorks gateway to retrieve
-  information about the current clusters using the user's API key.
+  This script will automatically connect to the ParallelWorks gateway to retrieve
+  information about storage resources using the user's API key.
+
+  It will then generate short-term credentials for the buckets provided
 
   Critical files that must exist:
 
@@ -30,7 +32,6 @@ else:
 pw_url = "https://" + PW_PLATFORM_HOST
 
 # specify the clusters to start and wait for activation
-#clusters = ["gcluster_noaa"]
 buckets_to_access = sys.argv[1].split(',')
 
 print('\nGenerating credentials for buckets:', buckets_to_access)

--- a/startClusters.py
+++ b/startClusters.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-  This script will automatically connect to the NOAA ParallelWorks gateway to retrieve
+  This script will automatically connect to the ParallelWorks gateway to retrieve
   information about the current clusters using the user's API key.
 
   Critical files that must exist:
@@ -38,7 +38,6 @@ else:
 pw_url = "https://" + PW_PLATFORM_HOST
 
 # specify the clusters to start and wait for activation
-#clusters = ["gcluster_noaa"]
 clusters_to_start = sys.argv[1].split(',')
 
 print('\nStarting clusters:', clusters_to_start)

--- a/stopClusters.py
+++ b/stopClusters.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-  This script will automatically connect to the NOAA ParallelWorks gateway to retrieve
+  This script will automatically connect to the ParallelWorks gateway to retrieve
   information about the current clusters using the user's API key.
 
   Critical files that must exist:
@@ -28,7 +28,6 @@ else:
 
 pw_url = "https://" + PW_PLATFORM_HOST
 # specify the clusters to start and wait for activation
-#clusters = ["gcluster_noaa"]
 clusters_to_stop = sys.argv[1].split(',')
 
 # used to run test ssh commands after the clusters start


### PR DESCRIPTION
Started to add some API examples to the client to retrieve storage information, and a script that can pull bucket credentials.

The argument structure is slightly different from the cluster start/stop examples. Since storage names are not unique between users, and since storages are likely to be shared with group members, I added some namespace parsing to the arguments.

For example, you can run the following command to get credentials for two different buckets:

```
./getBucketCred.py awsbucket,mlong/awsbucket,steve/awsbucket

Generating credentials for buckets: ['awsbucket', 'mlong/awsbucket', 'steve/awsbucket']

Running as user mlong...
No namespace provided for awsbucket. Default to current user mlong

Looking for bucket awsbucket in namespace mlong...
Identified bucket awsbucket as 65396675f704d94cf2be8765
xxx

Looking for bucket awsbucket in namespace mlong...
Identified bucket awsbucket as 65396675f704d94cf2be8765
xxx

Looking for bucket awsbucket in namespace steve...
Identified bucket awsbucket as 653189fc6046dedc3b7d460f
xxx

# xxx lines are where the credentials would be
```
* The first argument `awsbucket` has no namespace associated with it, so it defaults to the authenticated user's namespace.
* `mlong/awsbucket` resolves to the same bucket as the first argument, but uses an explicit namespace
* `steve/awsbucket` is another user's bucket that has been shared with me. Notice how the mapped resource ID is different.

I have also included (commented out) functions for starting and stopping storages. I have the start script mostly working, but I want to add some additional checks and status monitors to it before release.

The driver for the credential update is a request from Orion to be able to programmatically retrieve bucket keys, so I will be sharing these scripts with them directly.

I also removed some leftover NOAA references from the code.
