### PR TITLE
Resource label naming convention

### DIFF
--- a/runWorkflow.py
+++ b/runWorkflow.py
@@ -86,7 +86,7 @@ inputs = {
     "startCmd" : "main.sh",
 
     # Define which resource to run (should not be changed)
-    "resource_label": {
+    "resource": {
         "id" : resource_id,
         "type": "computeResource"
     }


### PR DESCRIPTION
In runWorkflow, the JSON package includes "resource_label", but the script-submitter tutorial workflow (i.e. [default bash workflow on platform](https://github.com/parallelworks/workflow_tutorial/blob/main/008_script_submitter/workflow.xml)) uses "resource". I think we should pick "resource" but I don't know if this will break other workflows.